### PR TITLE
Bug 1335687 - Rename "os_arch_" to "osarch_" and update the docs

### DIFF
--- a/report/format.md
+++ b/report/format.md
@@ -30,32 +30,37 @@ Reported Data
 -------------
 The following is a list of the reported dimensions for the aggregated data:
 
-* `browser_arch`: the architecture of the browser, either `x86` or `x86-64`.
-* `cores`: the number of CPU cores.
-* `cpu`: the name of the CPU vendor.
-* `cpu_speed`: the speed of the CPU in GHz, rounded to the first decimal number.
-* `cpu_cores_speed`: the number of cores aggregated with the speed of the CPU in GHz, rounded to the first decimal number.
-* `gpu`: the name of the vendor for the main video card.
-* `gpu_model`: the model for the main video card, derived from the reported vendor and device identifiers.
-* `display`: the resolution of the main screen, as a "WIDTHxHEIGHT" string. The width can be prefixed with a `~`, indicating that the resolution was rounded to the nearest hundredth.
+* `browserArch`: the architecture of the browser, either `x86` or `x86-64`.
+* `cpuCores`: the number of CPU cores.
+* `cpuVendor`: the name of the CPU vendor.
+* `cpuSpeed`: the speed of the CPU in GHz, rounded to the first decimal number.
+* `cpuCoresSpeed`: the number of cores aggregated with the speed of the CPU in GHz, rounded to the first decimal number.
+* `gpuVendor`: the name of the vendor for the main video card.
+* `gpuModel`: the model for the main video card, derived from the reported vendor and device identifiers.
+* `resolution`: the resolution of the main screen, as a "WIDTHxHEIGHT" string. The width can be prefixed with a `~`, indicating that the resolution was rounded to the nearest hundredth.
 * `ram`: the amount of installed RAM memory, in Gb.
-* `os`: the name and version of the installed Operating System.
-* `os_arch`: the architecture of the Operating System, either `x86` or `x86-64`.
-* `has_flash`: either `True` or `False`, depending on whether or not the Flash plugin is present.
+* `osName`: the name and version of the installed Operating System.
+* `osArch`: the architecture of the Operating System, either `x86` or `x86-64`.
+* `hasFlash`: either `True` or `False`, depending on whether or not the Flash plugin is present.
 
 **Example**
 ```json
 [
   {
-    "browser_arch_x86": 0.6,
-    "browser_arch_x86-64": 0.4,
-    "cores_1": 0.1,
-    "cores_2": 0.4,
-    "cores_4": 0.2,
-    "cores_Other": 0.3,
+    "browserArch_x86": 0.6,
+    "browserArch_x86-64": 0.4,
+    "cpuCores_1": 0.1,
+    "cpuCores_2": 0.4,
+    "cpuCores_4": 0.2,
+    "cpuCores_Other": 0.3,
     "date": "2016-05-01",
   },
 ]
 ```
 
 Means that 60% of the reference user population reported the use of Firefox x86 while 40% reported the use of Firefox x86-64. The reported number of CPU cores are a bit more fragmented: 10% report 1 core, 40% 2 cores and 20% 4 cores. Moreover, 30% of the users report a less common number of cores, so they are grouped together in the "Other" bucket.
+
+Changelog
+---------
+
+* 6ea4922162eddd85d890f18a2538d5edc18b8039 - Renamed the data points to use the camelCase (e.g. *os_arch_* becomes *osArch_*);

--- a/report/summarize_json.ipynb
+++ b/report/summarize_json.ipynb
@@ -457,18 +457,18 @@
     "    }\n",
     "\n",
     "    keys_translation = {\n",
-    "        'browser_arch': 'browser_arch_',\n",
-    "        'cpu_cores': 'cores_',\n",
-    "        'cpu_cores_speed': 'core_speed_',\n",
-    "        'cpu_vendor': 'cpu_',\n",
-    "        'cpu_speed': 'cpu_speed_',\n",
-    "        'gfx0_vendor_name': 'gpu_',\n",
-    "        'gfx0_model': 'gpu_model_',\n",
-    "        'resolution': 'display_',\n",
+    "        'browser_arch': 'browserArch_',\n",
+    "        'cpu_cores': 'cpuCores_',\n",
+    "        'cpu_cores_speed': 'cpuCoresSpeed_',\n",
+    "        'cpu_vendor': 'cpuVendor_',\n",
+    "        'cpu_speed': 'cpuSpeed_',\n",
+    "        'gfx0_vendor_name': 'gpuVendor_',\n",
+    "        'gfx0_model': 'gpuModel_',\n",
+    "        'resolution': 'resolution_',\n",
     "        'memory_gb': 'ram_',\n",
-    "        'os': 'os_',\n",
-    "        'os_arch': 'os_arch_',\n",
-    "        'has_flash': 'has_flash_'\n",
+    "        'os': 'osName_',\n",
+    "        'os_arch': 'osArch_',\n",
+    "        'has_flash': 'hasFlash_'\n",
     "    }\n",
     "\n",
     "    # Compute the percentages from the raw numbers.\n",
@@ -1015,6 +1015,15 @@
     "\n",
     "run_tests()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
I've also attempted to reference the github commit hash in the changelog.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/firefox-hardware-survey/18)
<!-- Reviewable:end -->
